### PR TITLE
Support remote debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,16 @@
                 "type": "array",
                 "description": "Commands executed at the end of debugging session.",
                 "default": []
+              },
+              "LLDBVSCodeHost": {
+                "type": "string",
+                "description": "Remote host to connect to for remote debugging",
+                "default": null
+              },
+              "LLDBVSCodePort": {
+                "type": "number",
+                "description": "Remote Port to connect to for remote debugging",
+                "default": null
               }
             }
           },
@@ -237,6 +247,16 @@
                 "type": "array",
                 "description": "Commands executed at the end of debugging session.",
                 "default": []
+              },
+              "LLDBVSCodeHost": {
+                "type": "string",
+                "description": "Remote host to connect to for remote debugging",
+                "default": null
+              },
+              "LLDBVSCodePort": {
+                "type": "number",
+                "description": "Remote Port to connect to for remote debugging",
+                "default": null
               }
             }
           }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,15 +79,23 @@ class LLDBDebugAdapterDescriptorFactory
   }
 
   createDebugAdapterDescriptor(
-    _1: vscode.DebugSession,
+    session: vscode.DebugSession,
     _2: vscode.DebugAdapterExecutable | undefined
   ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-    this.logger.show();
-    this.dispose();
+    const host: string | undefined = session.configuration["LLDBVSCodeHost"];
+    const port: number | undefined = session.configuration["LLDBVSCodePort"];
 
-    this.middlewareDap = new MiddlewareDap(this.logger);
-    // make VS Code connect to debug server
-    return new vscode.DebugAdapterServer(this.middlewareDap.getVSCodePort());
+    if (port == undefined) {
+      this.logger.show();
+      this.dispose();
+
+      this.middlewareDap = new MiddlewareDap(this.logger);
+      // make VS Code connect to debug server
+      return new vscode.DebugAdapterServer(this.middlewareDap.getVSCodePort());
+    }
+
+    // Connect to remote instance of lldb-vscode.
+    return new vscode.DebugAdapterServer(port, host);
   }
 
   dispose() {


### PR DESCRIPTION
The LLDBVSCodeHost and LLDBVSCodePort options allow connecting to
a remote instance of lldb-vscode.